### PR TITLE
Add readiness and liveness probes

### DIFF
--- a/deploy.yml
+++ b/deploy.yml
@@ -17,3 +17,13 @@ spec:
         - name: rack-app
           image: rack-app:latest
           imagePullPolicy: IfNotPresent
+          readinessProbe:
+            httpGet:
+              path: /
+              port: 9292
+          livenessProde:
+            httpGet:
+              path: /
+              port: 9292
+            initialDelaySeconds: 2
+            periodSeconds: 5


### PR DESCRIPTION
This commit adds both readiness and liveness probes to our deploy.yml. These are necessary to inform Kubernetes on the lifecycle state of our pod during operation.