### PR TITLE
Add commit sha to deploy tag

### DIFF
--- a/deploy.yml
+++ b/deploy.yml
@@ -15,7 +15,7 @@ spec:
     spec:
       containers:
         - name: rack-app
-          image: rack-app:latest
+          image: rack-app:deploy-$COMMITISH
           imagePullPolicy: IfNotPresent
           readinessProbe:
             httpGet:


### PR DESCRIPTION
In order to ensure we deploy a specific version of our app, this commit modifies the deploy.yml file to use deploy-$COMMITISH as the specific tag we are deploying. When we run bin/deploy, $COMMITISH gets replaced with our current commit's first 8 characters of the sha. This results in a unique container image tag for a deploy without changing the contents of the deploy.yml.