### PR TITLE
Fix liveness probe spelling in deploy.yml

### DIFF
--- a/deploy.yml
+++ b/deploy.yml
@@ -21,7 +21,7 @@ spec:
             httpGet:
               path: /
               port: 9292
-          livenessProde:
+          livenessProbe:
             httpGet:
               path: /
               port: 9292


### PR DESCRIPTION
This commit fixes a spelling mistake in the liveness probe for the rack app pod in deploy.yml.