### PR TITLE
Add all interface listen for rack-app

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,5 +10,7 @@ RUN apk --update add --no-cache --virtual run-dependencies \
 # copy our app.ru file into the filesystem of our image
 COPY app.ru app.ru
 
+EXPOSE 9292
+
 # run our application via rackup
-CMD rackup app.ru
+CMD ["rackup", "-o", "0.0.0.0", "app.ru"]

--- a/bin/docker-build-image
+++ b/bin/docker-build-image
@@ -7,7 +7,7 @@ set -e
 COMMITISH="$(git rev-parse HEAD | CUT -c 1-8)"
 BRANCH="$(git rev-parse --abbrev-ref HEAD)"
 PWD="$(pwd)"
-PROJECT_NAME="$(basename $PWD)"
+PROJECT_NAME="rack-app"
 
 docker build -t "$PROJECT_NAME:$BRANCH" .
 


### PR DESCRIPTION
In order to ensure we can properly route requests within a kubernetes cluster to our example rack-app, this commit changes the Dockerfile to listen on all interfaces (0.0.0.0) instead of localhost. This is necessary as within a kubernetes cluster, the request won't originate within the pod itself which means we won't be communicating with our pod properly.

Additionally, we hardcode the project name in the docker-build-image script as the other files expect the project name to be rack-app. This should handle the case where the project directory name can't break the expectations of the example project.